### PR TITLE
Limit file upload size

### DIFF
--- a/docassemble/MotionToStayEviction/data/questions/SP6A.yml
+++ b/docassemble/MotionToStayEviction/data/questions/SP6A.yml
@@ -67,7 +67,7 @@ code: |
   method_of_service
   parties_to_be_served
   service_date
-  max_mb_per_file = 0.3
+  max_mb_per_file
   if has_evidence:
     review_exhibits
     for exhibit in exhibits:
@@ -84,6 +84,13 @@ code: |
   basic_questions_signature_flow
   users[0].signature
   download
+---
+code: |
+  max_mb_per_file = 0.3
+---
+template: file_size_error_message
+content: |
+  The size of all the files together needs to be less than ${ max_mb_per_file } mb
 ---
 id: noa confirmation
 question: |

--- a/docassemble/MotionToStayEviction/data/questions/SP6A.yml
+++ b/docassemble/MotionToStayEviction/data/questions/SP6A.yml
@@ -86,22 +86,9 @@ code: |
   users[0].signature
   download
 ---
-# TODO: make file size error message translatable. To try:
-# code: |
-#  str_var = str( template_var )
-#---
-#template: template_var
-#content: |
-#  Some content
-#---
 code: |
-  max_mb_per_file = 0.3
-  #file_size_error_message = str(file_size_error_message_template)
+  max_mb_per_file = 15
   file_size_vars = True
----
-#template: file_size_error_message_template
-#content: |
-#  The size of all the files together needs to be less than ${ max_mb_per_file } mb
 ---
 id: noa confirmation
 question: |

--- a/docassemble/MotionToStayEviction/data/questions/SP6A.yml
+++ b/docassemble/MotionToStayEviction/data/questions/SP6A.yml
@@ -8,6 +8,10 @@ include:
 metadata:
   title: Appeal or Stay Your Eviction
 ---
+features:
+  javascript:
+    - limit_upload_size.js
+---
 code: |
   bcc_failsafe = "cc@example.com"
 ---
@@ -63,6 +67,8 @@ code: |
   method_of_service
   parties_to_be_served
   service_date
+  max_mb_per_file = 0.01
+  #set_max_filesize_mb( 0.01 )
   if has_evidence:
     review_exhibits
     for exhibit in exhibits:

--- a/docassemble/MotionToStayEviction/data/questions/SP6A.yml
+++ b/docassemble/MotionToStayEviction/data/questions/SP6A.yml
@@ -67,7 +67,7 @@ code: |
   method_of_service
   parties_to_be_served
   service_date
-  max_mb_per_file = 0.01
+  max_mb_per_file = 0.3
   if has_evidence:
     review_exhibits
     for exhibit in exhibits:

--- a/docassemble/MotionToStayEviction/data/questions/SP6A.yml
+++ b/docassemble/MotionToStayEviction/data/questions/SP6A.yml
@@ -67,7 +67,8 @@ code: |
   method_of_service
   parties_to_be_served
   service_date
-  max_mb_per_file
+  # WARNING: file size error is not currently translatable
+  file_size_vars
   if has_evidence:
     review_exhibits
     for exhibit in exhibits:
@@ -85,12 +86,22 @@ code: |
   users[0].signature
   download
 ---
+# TODO: make file size error message translatable. To try:
+# code: |
+#  str_var = str( template_var )
+#---
+#template: template_var
+#content: |
+#  Some content
+#---
 code: |
   max_mb_per_file = 0.3
+  #file_size_error_message = str(file_size_error_message_template)
+  file_size_vars = True
 ---
-template: file_size_error_message
-content: |
-  The size of all the files together needs to be less than ${ max_mb_per_file } mb
+#template: file_size_error_message_template
+#content: |
+#  The size of all the files together needs to be less than ${ max_mb_per_file } mb
 ---
 id: noa confirmation
 question: |

--- a/docassemble/MotionToStayEviction/data/questions/SP6A.yml
+++ b/docassemble/MotionToStayEviction/data/questions/SP6A.yml
@@ -68,7 +68,6 @@ code: |
   parties_to_be_served
   service_date
   max_mb_per_file = 0.01
-  #set_max_filesize_mb( 0.01 )
   if has_evidence:
     review_exhibits
     for exhibit in exhibits:

--- a/docassemble/MotionToStayEviction/data/static/limit_upload_size.js
+++ b/docassemble/MotionToStayEviction/data/static/limit_upload_size.js
@@ -1,0 +1,61 @@
+// Limit upload size of file
+
+// TODO: How to keep track of total size of all files since files can be added on different pages.
+
+let dom_data = {};
+
+let clear_error = function () {
+  /* Removes error message, enables continue button. */
+  let $error = $(`.da-field-container-datatype-files label.da-has-error`);
+  // We can fiddle with this behavior if desired.
+  $error.css( 'display', 'none' );
+  $error.text( '' );
+  
+  // re-enable continue button
+  let next = document.querySelector('.da-field-buttons button[type="submit"]');
+  next.disabled = false;
+  
+  // Clear listeners so they don't pile up
+  $('.fileinput-remove').off( 'click', clear_error );
+};   // Ends clear_error()
+
+let prevent_big_files = function ( var_data ) {
+  /* Shows an error if a upload is too big and deletes the files */
+  let max_mb = var_data.variables.max_mb_per_file;
+  let max_bytes = max_mb * 1000 * 1000;
+  let files = dom_data.upload_node.files
+  console.log( var_data.variables.file_size_error_message );
+
+  let total_size = 0;
+  for ( let file of files ) { total_size += file.size; }
+  let is_too_big = total_size > max_bytes;
+  if ( total_size > max_bytes ) {
+    let $error = $(`.da-field-container-datatype-files label.da-has-error`);
+    $error.css( 'display', 'inline-block' );
+    $error.text( `The size of all the files together needs to be less than ${ max_mb } mb` );
+    // When the files are removed in here, the display
+    // looks the same, which is very confusing. Instead
+    // we're disabling the 'Next' button
+    let next = document.querySelector('.da-field-buttons button[type="submit"]');
+    next.disabled = true;
+    
+    // Listen for removal of file
+    $('.fileinput-remove').on( 'click', clear_error );
+    
+  } else { clear_error(); }
+};  // Ends prevent_big_files()
+
+$( document ).ready(function () {
+  
+  $('.dafile').on( 'change', function (evnt) {
+    dom_data.upload_node = evnt.target;
+    get_interview_variables( prevent_big_files );
+  });
+  
+  $(document.body).on('drop', function (event) {
+    let files_input = document.querySelector('.dafile');
+    dom_data.upload_node = document.querySelector('.dafile');
+    get_interview_variables( prevent_big_files );
+  });
+
+});

--- a/docassemble/MotionToStayEviction/data/static/limit_upload_size.js
+++ b/docassemble/MotionToStayEviction/data/static/limit_upload_size.js
@@ -1,6 +1,7 @@
 // Limit upload size of file
 
-// TODO: How to keep track of total size of all files since files can be added on different pages.
+// TODO: Explore CustomDatatype js instead of the js in here
+// TODO: Keep track of total size of all files since files can be added on different pages.
 
 let dom_data = {};
 
@@ -20,42 +21,46 @@ let clear_error = function () {
 };   // Ends clear_error()
 
 let prevent_big_files = function ( var_data ) {
-  /* Shows an error if a upload is too big and deletes the files */
+  /* If the size of uploaded files is too big, show an
+  *    error and don't allow the user to continue. */
   let max_mb = var_data.variables.max_mb_per_file;
   let max_bytes = max_mb * 1000 * 1000;
   let files = dom_data.upload_node.files
-  console.log( var_data.variables.file_size_error_message );
 
   let total_size = 0;
   for ( let file of files ) { total_size += file.size; }
-  let is_too_big = total_size > max_bytes;
   if ( total_size > max_bytes ) {
     let $error = $(`.da-field-container-datatype-files label.da-has-error`);
     $error.css( 'display', 'inline-block' );
+    // WARNING: This message is not going to be translated currently
+    // See notes in YAML about possibly translating: var_data.variables.file_size_error_message
     $error.text( `The size of all the files together needs to be less than ${ max_mb } mb` );
-    // When the files are removed in here, the display
-    // looks the same, which is very confusing. Instead
-    // we're disabling the 'Next' button
+    // Disable continuing to next page.
     let next = document.querySelector('.da-field-buttons button[type="submit"]');
     next.disabled = true;
     
     // Listen for removal of file
     $('.fileinput-remove').on( 'click', clear_error );
     
+  // Otherwise make sure the error state stuff is removed/not present
   } else { clear_error(); }
 };  // Ends prevent_big_files()
 
+
+
 $( document ).ready(function () {
+  // When the document is ready, start listening for the relevant events
   
+  // The file input field itself changing (getting a value)
   $('.dafile').on( 'change', function (evnt) {
     dom_data.upload_node = evnt.target;
-    get_interview_variables( prevent_big_files );
+    get_interview_variables( prevent_big_files );  // A da function
   });
   
+  // The drag and drop area getting a file dropped
   $(document.body).on('drop', function (event) {
-    let files_input = document.querySelector('.dafile');
     dom_data.upload_node = document.querySelector('.dafile');
-    get_interview_variables( prevent_big_files );
+    get_interview_variables( prevent_big_files );  // A da function
   });
 
 });


### PR DESCRIPTION
Limited to 0.04mb right now, editable in the YAML. Larger file sizes (16mb, etc) haven't been tested for server error.

Doesn't close limit on PDF I think.