### PR TITLE
Actually print the email that you're sending to

### DIFF
--- a/docassemble/MotionToStayEviction/data/questions/old_mavc_appeals_basic_questions.yml
+++ b/docassemble/MotionToStayEviction/data/questions/old_mavc_appeals_basic_questions.yml
@@ -214,7 +214,7 @@ code: |
   # email_to_use = "massaccess@suffolk.edu"
   
   if task_not_yet_performed('send email'):
-    log("Court email is " + court_email)
+    log(f"Court email is {court_email}, sending to {email_to_use}")
     email_success = False
     if should_cc_user:
       log('Sending email to ' + email_to_use + ' and ccing ' + cc_email + ' for ' + str(users))

--- a/docassemble/MotionToStayEviction/data/questions/old_mavc_appeals_basic_questions.yml
+++ b/docassemble/MotionToStayEviction/data/questions/old_mavc_appeals_basic_questions.yml
@@ -198,17 +198,33 @@ fields:
   - My preferred language is: user_preferred_language
     show if: user_needs_interpreter
 ---
+code: |
+ def will_send_to_real_court():
+    """
+    For legacy email to court forms, this checks to see if the form
+    is being run locally, or on the dev, test, or production servers.
+
+    The text "dev" or "test" needs to be in the URL root in the DA config: can change in `/config`.
+    """
+    return not (
+        get_config("debug")
+        or "dev" in get_config("url root")
+        or "test" in get_config("url root")
+        or "localhost" in get_config("url root")
+    ) 
+---
 comment: |
   Send to court code--tweaked slightly for MAC
 need:
+  - will_send_to_real_court
   - email_to_court_template
   - court_email
   - should_cc_user
 code: |
-  if 'dev' in get_config('url root') or 'test' in get_config('url root'):
-    email_to_use = "massaccess@suffolk.edu"
-  else:
+  if will_send_to_real_court():
     email_to_use = court_email
+  else:
+    email_to_use = "massaccess@suffolk.edu"
   
   # temporary for testing
   # email_to_use = "massaccess@suffolk.edu"


### PR DESCRIPTION
This is necessary, as it's caused issues on production in the past. However, I'm not going to merge, as #61 will likely be merged and be used first; when we switch over to using the Appeals court's e-filing system, they will stop accepting emails, and this code will be useless anyway. If no progress has been made on the Appeals court's side by May, I'll merge and try to get this to production.