### PR TITLE
Actually filter disclaimers

### DIFF
--- a/docassemble/MotionToStayEviction/data/questions/efiling.yml
+++ b/docassemble/MotionToStayEviction/data/questions/efiling.yml
@@ -389,7 +389,7 @@ code: |
 ---
 code: |
   redundant_disclaimers = [
-    "A certificate of service is included."
+    "A certificate of service is included.",
     "All scanned PDFs are text searchable using optical character recognition (OCR)."
   ]
   disclaimers_tmp = sorted(proxy_conn.get_disclaimers(court_id).data, key=lambda yy: yy.get("listorder", yy.get("code")))


### PR DESCRIPTION
The missing comma meant that python concatenated the two strings instead of keeping them as two separate strings in the list.