### PR TITLE
Stop misplaced searches for Housing dockets

### DIFF
--- a/docassemble/MotionToStayEviction/data/questions/SP6A.yml
+++ b/docassemble/MotionToStayEviction/data/questions/SP6A.yml
@@ -110,6 +110,8 @@ code: |
     if not is_initial_filing:
       appeals_case_search.do_what_choice
       appeals_case_search.case_was_found
+      if appeals_case_search.court_id != "appeals:acp" and appeals_case_search.court_id != "appeals:acsj":
+        should_search_for_appeals_court
       lower_court_case.docket_number = appeals_case_search.found_case.docket_number
       previous_case_id = appeals_case_search.found_case.tracking_id
       target_case = appeals_case_search

--- a/docassemble/MotionToStayEviction/data/questions/efiling.yml
+++ b/docassemble/MotionToStayEviction/data/questions/efiling.yml
@@ -310,6 +310,8 @@ code: |
   timing = 'Initial'
   housing_case_search.do_what_choice = appeals_case_search.do_what_choice
   housing_case_search.court_id = appeals_case_search.court_id
+  del previous_case_id
+  court_id = housing_case_search.court_id
   #housing_case_search.found_case = appeals_case_search.found_case.copy_deep('housing_case_search.found_case')
   #housing_case_search.case_was_found = appeals_case_search.case_was_found
 ---


### PR DESCRIPTION
If people say it's not their first filing into the appeals court, but still search for a housing court number, we should stop them, because they won't be able to file later.