### PR TITLE
Fix efile issue - update eFile value to reduce string size

### DIFF
--- a/docassemble/MotionToStayEviction/data/questions/efiling.yml
+++ b/docassemble/MotionToStayEviction/data/questions/efiling.yml
@@ -33,7 +33,7 @@ code: |
   efile_case_category_filters = ['Appeals Court Single Justice - Civil', 'Civil']
   efile_case_category_default = '8151'
   efile_case_category_exclude = None
-  efile_case_type_filters = ['MAC Rule 6.0 - Motion to Stay']
+  efile_case_type_filters = ['MAC Rule 6.0']
   # Prod and stage have diverged; using prod value here
   efile_case_type_default = '12644'
   efile_case_type_exclude = None


### PR DESCRIPTION
Here's my understanding of the issue. Error message we're trying to fix:
```
More details: Response Code: 400({‘name’: ‘efile_case_type’, ‘description’: ‘’, ‘datatype’: ‘choice’, ‘choices’: [‘Appeal bond c 239 s 5’, ‘Motion to file late notice of appeal’, ‘Petition under c 231 s 118 p1’, ‘Impounded Case’, ‘Motion to order assembly’, ‘Appeal under c.212, s3A’, ‘Motion for Misc Relief’, ‘MAC Rule 6.0 – Motion to stay’, ‘Attorneys fees under c 231 s 6G’, ‘Indigency appeal c 261 s 27D’, ‘Motion for stay of judgment MRAP 6(a)’, ‘Motion to docket appeal late’]})
```

The values listed in the error represent the ones that Tyler expects. Here's the value we're actually sending ([code](https://github.com/SuffolkLITLab/docassemble-MotionToStayEviction/blob/3b90cbb6f04246c87bcf914238a8a0e9faa64def/docassemble/MotionToStayEviction/data/questions/efiling.yml#L36)):
```
MAC Rule 6.0 - Motion to Stay
```

Though similar, the dash values are slightly different ("-" vs "–"). My understanding is that due to the way we filter these values, we can shorten the string and it will still match. And this is _preferred_ because we don't want this to break due to something like a change in punctuation, as may be happening now. 