### PR TITLE
Restrict max size per document

### DIFF
--- a/docassemble/MotionToStayEviction/data/questions/SP6A.yml
+++ b/docassemble/MotionToStayEviction/data/questions/SP6A.yml
@@ -149,7 +149,7 @@ code: |
 # Uses max_size from Tyler
 if: can_check_efile
 objects:
-  - exhibit_doc: ALExhibitDocument.using(title="Exhibits", filename='exhibits', bates_prefix="EX-", include_exhibit_cover_page=True, include_table_of_contents=True, add_page_numbers=True, auto_ocr=True, maximum_size=max_total_exhibit_size)
+  - exhibit_doc: ALExhibitDocument.using(title="Exhibits", filename='exhibits', bates_prefix="EX-", include_exhibit_cover_page=True, include_table_of_contents=True, add_page_numbers=True, auto_ocr=True, maximum_size=max_total_exhibit_size, maximum_size_per_doc=max_per_file)
 ---
 if: not can_check_efile
 objects:
@@ -1074,8 +1074,16 @@ fields:
     show if: x.has_exhibits
 validation code: |
   if x.has_exhibits:
-    if sum(exhibit.size_in_bytes() for exhibit in x[0].pages) > (15 * 1024 * 1024):
+    this_doc_size = sum(exhibit.size_in_bytes() for exhibit in x[0].pages)
+    if hasattr(x, 'maximum_size_per_doc'):
+      if this_doc_size > x.maximum_size_per_doc:
+        validation_error(f"This document should be smaller than {humanize.naturalsize(x.maximum_size_per_doc)}")
+    if this_doc_size > (15 * 1024 * 1024):
       validation_error("Upload a file smaller than 15 MB.")
+    if hasattr(x, 'maximum_size'):
+      if this_doc_size > x.maximum_size:
+        suggested_size = x.maximum_size - this_doc_size
+        validation_error(f"All exhibits combined must be smaller than {humanize.naturalsize(x.maximum_size)}. Upload a file smaller than {humanize.naturalsize(suggested_size)}.")
     try:
       pdf_concatenate(x[0].pages)
     except:

--- a/docassemble/MotionToStayEviction/data/questions/efiling.yml
+++ b/docassemble/MotionToStayEviction/data/questions/efiling.yml
@@ -91,9 +91,15 @@ only sets:
   - max_mb_per_file
 code: |
   allowed_sizes = get_max_allowed_sizes(proxy_conn, court_id)
+  one_mb = 1024 * 1024
   if allowed_sizes:
     max_mb_per_file = allowed_sizes[0] / 1024 / 1024
-    max_total_exhibit_size = allowed_sizes[1]
+    if allowed_size[0] > one_mb:
+      # OCR will increase file sizes a bit, so save some room
+      max_per_file = allowed_sizes[0] - one_mb
+    else:
+      max_per_file = allowed_sizes[0]
+    max_total_exhibit_size = allowed_sizes[1] - one_mb
   else:
     max_mb_per_file = 15
     max_total_exhibit_size = 50 * 1024 * 1024


### PR DESCRIPTION
Uses the new `maximum_size_per_doc` param to the ALExhibits object to limit the size of individual documents.

In order to attempt to account for the OCR'd layer on the PDF (which is added after the user uploads their files), it makes the limit stricter by 1 MB. Might not be enough, but it gets more difficult when the document that is upload isn't the exact same one that we submit.

Depends on https://github.com/SuffolkLITLab/docassemble-AssemblyLine/pull/1002.