### PR TITLE
Fixed bugs in interview tests

### DIFF
--- a/docassemble/MotionToStayEviction/data/questions/efiling.yml
+++ b/docassemble/MotionToStayEviction/data/questions/efiling.yml
@@ -94,7 +94,7 @@ code: |
   one_mb = 1024 * 1024
   if allowed_sizes:
     max_mb_per_file = allowed_sizes[0] / 1024 / 1024
-    if allowed_size[0] > one_mb:
+    if allowed_sizes[0] > one_mb:
       # OCR will increase file sizes a bit, so save some room
       max_per_file = allowed_sizes[0] - one_mb
     else:

--- a/docassemble/MotionToStayEviction/data/sources/sp6a_interview.feature
+++ b/docassemble/MotionToStayEviction/data/sources/sp6a_interview.feature
@@ -21,7 +21,7 @@ Feature: Get through SP6A interview
       | var | value | trigger |
       | acknowledged_information_use['I accept the terms of use.'] | True | |
       | is_initial_filing | True | |
-      | user_wants_affidavit | False | |
+      | user_wants_efile | False | |
       | users[0].name.first | Bob | |
       | users[0].name.last | Ma | |
       | users[0].email | example@example.com | |
@@ -76,7 +76,7 @@ Feature: Get through SP6A interview
       | var | value | trigger |
       | acknowledged_information_use['I accept the terms of use.'] | True | |
       | is_initial_filing | True | |
-      | user_wants_affidavit | True | |
+      | user_wants_efile | True | |
     And I set the variable "my_username" to secret "TYLER_EMAIL"
     And I set the variable "my_password" to secret "TYLER_PASSWORD"
     Then I tap to continue
@@ -150,7 +150,7 @@ Feature: Get through SP6A interview
       | var | value | trigger |
       | acknowledged_information_use['I accept the terms of use.'] | True | |
       | is_initial_filing | True | |
-      | user_wants_affidavit | True | |
+      | user_wants_efile | True | |
     And I set the variable "my_username" to secret "TYLER_EMAIL"
     And I set the variable "my_password" to secret "TYLER_PASSWORD"
     Then I tap to continue


### PR DESCRIPTION
One interview bug introduced by #108 that wasn't caught (mispelled variable).

One test regression (`user_wants_affidavit` has changed to `user_wants_efile`).